### PR TITLE
Make `Fake` a monad transformer

### DIFF
--- a/fakedata.cabal
+++ b/fakedata.cabal
@@ -271,6 +271,7 @@ library
       Faker.Cannabis
       Faker.Chiquito
       Faker.ChuckNorris
+      Faker.Class
       Faker.Code
       Faker.Coffee
       Faker.Coin
@@ -609,6 +610,7 @@ library
     , template-haskell
     , text
     , time
+    , transformers
     , unordered-containers
     , vector
     , yaml
@@ -708,6 +710,7 @@ test-suite fakedata-test
     , template-haskell
     , text
     , time
+    , transformers
     , unordered-containers
     , vector
     , yaml
@@ -741,6 +744,7 @@ benchmark fakebench
     , template-haskell
     , text
     , time
+    , transformers
     , unordered-containers
     , vector
     , yaml

--- a/fakedata.cabal
+++ b/fakedata.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 47d937a2bbf041ef0cb0b882d0bf7d68d1eb9504988a12d676e9e699288f2bda
 
 name:           fakedata
 version:        0.8.0
@@ -595,7 +593,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      attoparsec
+      QuickCheck
+    , attoparsec
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -605,6 +604,7 @@ library
     , filepath
     , hashable
     , random
+    , regex-tdfa
     , string-random
     , template-haskell
     , text
@@ -689,7 +689,8 @@ test-suite fakedata-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      attoparsec
+      QuickCheck
+    , attoparsec
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -702,6 +703,7 @@ test-suite fakedata-test
     , hspec
     , hspec-discover
     , random
+    , regex-tdfa
     , string-random
     , template-haskell
     , text
@@ -709,8 +711,6 @@ test-suite fakedata-test
     , unordered-containers
     , vector
     , yaml
-    , regex-tdfa
-    , QuickCheck
   default-language: Haskell2010
 
 benchmark fakebench
@@ -722,7 +722,8 @@ benchmark fakebench
       bench
   ghc-options: -O2
   build-depends:
-      attoparsec
+      QuickCheck
+    , attoparsec
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -735,6 +736,7 @@ benchmark fakebench
     , gauge
     , hashable
     , random
+    , regex-tdfa
     , string-random
     , template-haskell
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,8 @@ dependencies:
 - string-random
 - fakedata-parser
 - attoparsec
+- regex-tdfa
+- QuickCheck
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ dependencies:
 - attoparsec
 - regex-tdfa
 - QuickCheck
+- transformers
 
 library:
   source-dirs: src

--- a/src/Faker/Address.hs
+++ b/src/Faker/Address.hs
@@ -4,7 +4,7 @@
 module Faker.Address where
 
 import Data.Text (Text)
-import Faker (Fake(..), FakerSettings(..), getLocale)
+import Faker (Fake, FakeT(..), FakerSettings(..), getLocale)
 import Faker.Internal (cachedRandomUnresolvedVec, cachedRandomVec, cachedRegex, RegexFakeValue(..))
 import Faker.Provider.Address
 import Faker.TH

--- a/src/Faker/Class.hs
+++ b/src/Faker/Class.hs
@@ -1,0 +1,33 @@
+module Faker.Class
+  ( MonadFake(..)
+  ) where
+
+import Faker (FakeT(..), Fake)
+
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class (MonadTrans(lift))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Identity (IdentityT)
+import Control.Monad.Trans.Maybe (MaybeT)
+import Control.Monad.Trans.Reader (ReaderT)
+import Control.Monad.Trans.State (StateT)
+import Control.Monad.Trans.Writer (WriterT)
+
+class Monad m => MonadFake m where
+  liftFake :: Fake a -> m a
+
+instance MonadIO m => MonadFake (FakeT m) where
+  liftFake (Fake f) = FakeT (liftIO . f)
+
+instance MonadFake m => MonadFake (ReaderT r m) where
+  liftFake = lift . liftFake
+instance (Monoid w, MonadFake m) => MonadFake (WriterT w m) where
+  liftFake = lift . liftFake
+instance MonadFake m => MonadFake (StateT s m) where
+  liftFake = lift . liftFake
+instance MonadFake m => MonadFake (IdentityT m) where
+  liftFake = lift . liftFake
+instance MonadFake m => MonadFake (ExceptT e m) where
+  liftFake = lift . liftFake
+instance MonadFake m => MonadFake (MaybeT m) where
+  liftFake = lift . liftFake


### PR DESCRIPTION
## Motivation

At my work, we were running lots of `Fake`s in a monad stack to generate very large amounts of data, but it was quite slow. When I did some profiling, I found that the biggest bottlenecks were work that `fakedata` does every time you generate a `Fake` - namely, parse the YAML files for the data, and build a cache for accessing it.

That meant that we should have been running all of our code inside a single `Fake`, to take advantage of the cache - but then we would have had to run our monad code in `IO`, since that's what's required by `Fake`. So instead, we created this monad transformer:
```haskell
newtype FakeT m a = FakeT (FakerSettings -> m a)
```
which works just like `Fake`, but with any monad stack we want, and still shares the cache.

We then lifted our `Fake`s to `FakeT`s
```haskell
class MonadFake m where
  liftFake :: Fake a -> m a
```
to allow us to run them using the `FakerSettings` from `FakerT`.

Using this monad transformer, we were able to share a single `FakerSettings`, including the cache, across lots of `Fake` values, without having to rewrite everything in terms of `IO`. This was a massive performance improvement. Since it was useful to us, I thought it would be good to contribute back to upstream.

## Breaking change

This is a breaking change, since importing `Fake(..)` is no longer enough to import the `Fake` constructor (which is now actually a pattern synonym).

## Future work

~I still want to go though `Faker.Combinators` to generalise them to `FakerT m` instead of `Fake`, but I thought I would share these changes first.~ This is done now.