### PR TITLE
Make `Fake` type synonym partially applied

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for fakedata
 
+## 1.0.3 (Unreleased)
+
+* [Make the `Fake` type synonym partially applied](https://github.com/fakedata-haskell/fakedata/pull/45)
+
 ## 1.0.2
 
 * Make it compatible with aeson 1 and 2.

--- a/src/Faker.hs
+++ b/src/Faker.hs
@@ -184,7 +184,7 @@ newtype FakeT m a = FakeT
 
 -- | Fake data type. This is the type you will be using to produce
 -- fake values.
-type Fake a = FakeT IO a
+type Fake = FakeT IO
 
 pattern Fake :: (FakerSettings -> IO a) -> Fake a
 pattern Fake f = FakeT f


### PR DESCRIPTION
Small QoL issue I noticed when using `Fake`.