### PR TITLE
Add `variedListOf`

### DIFF
--- a/src/Faker/Combinators.hs
+++ b/src/Faker/Combinators.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE ExplicitForAll #-}
+
 module Faker.Combinators where
 
 import Control.Monad
 import Data.Foldable
-import Data.List (sort)
+import Data.List (sort, unfoldr)
 import Faker
 import System.Random
 
@@ -14,13 +15,13 @@ import System.Random
 -- λ> item
 -- 2
 -- @
---
 fromRange :: forall a m. (Monad m, Random a) => (a, a) -> FakeT m a
 fromRange rng =
   FakeT
-    (\r ->
-       let (x, _) = randomR rng (getRandomGen r)
-        in pure x)
+    ( \r ->
+        let (x, _) = randomR rng (getRandomGen r)
+         in pure x
+    )
 
 -- | Generates a random element over the natural range of `a`.
 --
@@ -30,13 +31,13 @@ fromRange rng =
 -- λ> item
 -- 57
 -- @
---
 pickAny :: forall a m. (Monad m, Random a) => FakeT m a
 pickAny =
   FakeT
-    (\settings ->
-       let (x, _) = random (getRandomGen settings)
-        in pure x)
+    ( \settings ->
+        let (x, _) = random (getRandomGen settings)
+         in pure x
+    )
 
 -- | Tries to generate a value that satisfies a predicate.
 --
@@ -46,7 +47,6 @@ pickAny =
 -- λ> item
 -- Just Ecuador
 -- @
---
 suchThatMaybe :: forall a m. Monad m => FakeT m a -> (a -> Bool) -> FakeT m (Maybe a)
 gen `suchThatMaybe` p = do
   x <- gen
@@ -63,7 +63,6 @@ gen `suchThatMaybe` p = do
 -- λ> item
 -- Ecuador
 -- @
---
 suchThat :: forall a m. Monad m => FakeT m a -> (a -> Bool) -> FakeT m a
 gen `suchThat` p = do
   mx <- gen `suchThatMaybe` p
@@ -80,7 +79,6 @@ gen `suchThat` p = do
 -- λ> generate (oneof fakes)
 -- Montana
 -- @
---
 oneof :: forall t a m. (Monad m, Foldable t) => t (FakeT m a) -> FakeT m a
 oneof xs = helper
   where
@@ -97,7 +95,6 @@ oneof xs = helper
 -- λ> generate fakeInt
 -- 22
 -- @
---
 elements :: forall t a m. (Monad m, Foldable t) => t a -> FakeT m a
 elements xs =
   case items of
@@ -110,6 +107,19 @@ elements xs =
 listOf :: forall a m. Monad m => Int -> FakeT m a -> FakeT m [a]
 listOf = replicateM
 
+-- | A pure version of `listOf`. The resulting list will be the same each time (deterministic).
+deterministicListOf :: Int -> Fake a -> Fake [a]
+deterministicListOf n fakedata = FakeT $ \settings -> traverse generate $ take n $ unfoldr coalgebra settings
+  where
+    -- implemented as an anamorphism: `( settings -> (fakedata, newSettings) ) -> [fakedata]`
+    coalgebra fakerSettings =
+      Just
+        ( FakeT $ \settings -> runFakeT fakedata $ setRandomGen a fakerSettings,
+          setRandomGen b fakerSettings
+        )
+      where
+        (b, a) = split $ getRandomGen fakerSettings
+
 -- | Generates an ordered list.
 orderedList :: forall a m. (Monad m, Ord a) => Int -> FakeT m a -> FakeT m [a]
 orderedList n gen = sort <$> listOf n gen
@@ -121,7 +131,7 @@ frequency [] = error "Faker.Combinators.frequency used with empty list"
 frequency xs0 = fromRange (1, tot) >>= (`pick` xs0)
   where
     tot = sum (map fst xs0)
-    pick n ((k, x):xs)
+    pick n ((k, x) : xs)
       | n <= k = x
       | otherwise = pick (n - k) xs
     pick _ _ = error "FakeT m.pick used with empty list"
@@ -135,7 +145,6 @@ frequency xs0 = fromRange (1, tot) >>= (`pick` xs0)
 -- λ> generate (fakeEnumFromTo Cat Zebra)
 -- Zebra
 -- @
---
 fakeEnumFromTo :: forall a m. (Monad m, Enum a) => a -> a -> FakeT m a
 fakeEnumFromTo from to = toEnum <$> fromRange (fromEnum from, fromEnum to)
 
@@ -143,6 +152,5 @@ fakeEnumFromTo from to = toEnum <$> fromRange (fromEnum from, fromEnum to)
 -- fakeBoundedEnum = `fakeEnumFromTo` `minBound` `maxBound`
 --
 -- @since 0.7.1
---
 fakeBoundedEnum :: forall a m. (Monad m, Enum a, Bounded a) => FakeT m a
 fakeBoundedEnum = fakeEnumFromTo minBound maxBound

--- a/src/Faker/Combinators.hs
+++ b/src/Faker/Combinators.hs
@@ -107,9 +107,9 @@ elements xs =
 listOf :: forall a m. Monad m => Int -> FakeT m a -> FakeT m [a]
 listOf = replicateM
 
--- | A pure version of `listOf`. The resulting list will be the same each time (deterministic).
-deterministicListOf :: Int -> Fake a -> Fake [a]
-deterministicListOf n fakedata = FakeT $ \settings -> traverse generate $ take n $ unfoldr coalgebra settings
+-- | A pure version of `listOf`. The resulting list will be deterministic, while containing varied elements (unlike `listOf`).
+variedListOf :: Int -> Fake a -> Fake [a]
+variedListOf n fakedata = FakeT $ \settings -> traverse generate $ take n $ unfoldr coalgebra settings
   where
     -- implemented as an anamorphism: `( settings -> (fakedata, newSettings) ) -> [fakedata]`
     coalgebra fakerSettings =


### PR DESCRIPTION
`listOf` can be very frustrating. For example, this behavior is not what most people are expecting:

```
generate $ listOf 100 $ fromRange (0, 100)
>>>[38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38,38]
```

However, this is probably more intuitive:

```
generate $ variedListOf 100 $ fromRange (0, 100)
[67,4,63,82,33,38,57,79,22,52,13,86,22,45,4,100,0,90,22,31,71,27,36,73,70,12,77,22,40,81,29,10,54,37,94,69,36,25,7,15,76,70,81,5,86,4,45,28,82,0,92,46,91,89,97,7,98,36,55,38,43,28,76,87,84,18,52,38,17,78,25,11,98,8,78,10,11,75,75,35,6,78,68,75,62,87,38,53,51,64,22,56,3,91,64,52,38,64,39,35]
```